### PR TITLE
return if the backtrace is not there

### DIFF
--- a/lib/resque/failure/backtrace.rb
+++ b/lib/resque/failure/backtrace.rb
@@ -2,12 +2,8 @@ module Resque
   module Failure
     class Backtrace < Base
       def save
-        if exception.backtrace
-          bt = filter_backtrace(exception.backtrace)
-          worker.log bt.join("\n")
-        else
-          worker.log exception.inspect
-        end
+        bt = filter_backtrace(exception.backtrace || [])
+        worker.log bt.join("\n")
       end
 
       private

--- a/lib/resque/failure/backtrace.rb
+++ b/lib/resque/failure/backtrace.rb
@@ -2,14 +2,17 @@ module Resque
   module Failure
     class Backtrace < Base
       def save
-        bt = filter_backtrace(exception.backtrace)
-        worker.log bt.join("\n")
+        if exception.backtrace
+          bt = filter_backtrace(exception.backtrace)
+          worker.log bt.join("\n")
+        else
+          worker.log exception.inspect
+        end
       end
 
       private
 
       def filter_backtrace(backtrace)
-        return if backtrace.nil?
         index = backtrace.index { |item| item.include?('/lib/resque/job.rb') }
         backtrace.first(index.to_i)
       end

--- a/lib/resque/failure/backtrace.rb
+++ b/lib/resque/failure/backtrace.rb
@@ -9,6 +9,7 @@ module Resque
       private
 
       def filter_backtrace(backtrace)
+        return if backtrace.nil?
         index = backtrace.index { |item| item.include?('/lib/resque/job.rb') }
         backtrace.first(index.to_i)
       end


### PR DESCRIPTION
For example if a new error has been constructed but not thrown: https://github.com/resque/resque/blob/v1.25.2/lib/resque/worker.rb#L551

otherwise this raises calling index on nil
